### PR TITLE
Replace blake2b Git URL with npm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "bigi": "^1.4.0",
     "bip66": "^1.1.0",
     "bitcoin-ops": "^1.3.0",
-    "blake2b": "https://github.com/zelcore-io/blake2b",
+    "blake2b": "^2.1.4",
     "bs58check": "^2.0.0",
     "create-hash": "^1.1.0",
     "create-hmac": "^1.1.3",


### PR DESCRIPTION
Replace Github URL for npm version. Seem using URL is not working